### PR TITLE
fix: tooltip styles on Safari

### DIFF
--- a/src/components/Methods/methods.module.css
+++ b/src/components/Methods/methods.module.css
@@ -1,3 +1,4 @@
+.forbidden,
 .restrictedTo {
   display: flex;
   gap: var(--spacing-xs);


### PR DESCRIPTION
Crown icon showed up on own line after method name on both iOS and desktop Safari