### PR TITLE
feat: cache schema in localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@rjsf/core": "^4.1.0",
         "brotli-dec-wasm": "^1.3.0",
         "buffer": "^6.0.3",
+        "fast-deep-equal": "^3.1.3",
         "near-api-js": "github:AhaLabs/near-api-js#develop",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -6793,7 +6794,8 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -19834,7 +19836,9 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.11",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@rjsf/core": "^4.1.0",
     "brotli-dec-wasm": "^1.3.0",
     "buffer": "^6.0.3",
+    "fast-deep-equal": "^3.1.3",
     "near-api-js": "github:AhaLabs/near-api-js#develop",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/components/Methods/Method.tsx
+++ b/src/components/Methods/Method.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import useNear from '../../hooks/useNear';
+import css from './methods.module.css';
+
+export const Method: React.FC<React.PropsWithChildren<{
+  method: string,
+  element: JSX.Element,
+}>> = ({ method, element }) => {
+  const { canCall, wallet } = useNear()
+  const user = wallet?.getAccountId() as string
+  const [allowed, setAllowed] = useState<boolean>(true)
+  const [whyForbidden, setWhyForbidden] = useState<string>()
+  const { contract, method: currentMethod } = useParams<{ contract: string, method: string }>()
+
+  useEffect(() => {
+    canCall(method, user).then(can => {
+      setAllowed(can[0])
+      setWhyForbidden(can[1] || undefined)
+    })
+  }, [method, user, canCall])
+
+  if (currentMethod === method) {
+    return <div>{element}</div>
+  }
+
+  return (
+    <Link
+      to={`/${contract}/${method}`}
+      onClick={() => {
+        // clear any params set by NEAR Wallet when navigating to new method
+        window.history.pushState(null, '',
+          window.location.href.replace(window.location.search, '')
+        )
+      }}
+      className={allowed ? undefined : css.forbidden}
+      title={allowed ? undefined : `Forbidden: ${whyForbidden}`}
+    >
+      {element}
+    </Link>
+  )
+}

--- a/src/components/Methods/Method.tsx
+++ b/src/components/Methods/Method.tsx
@@ -62,7 +62,10 @@ export const Method: React.FC<{
 
   if (isCurrentMethod) {
     return (
-      <div>
+      <div
+        className={allowed ? undefined : css.forbidden}
+        title={allowed ? undefined : `Forbidden: ${whyForbidden}`}
+      >
         {snake(method)}
         <Tip method={method} />
       </div>

--- a/src/components/Methods/Method.tsx
+++ b/src/components/Methods/Method.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import snake from "to-snake-case";
-import { useParams, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Root as Tooltip, Trigger, Content, Arrow } from '@radix-ui/react-tooltip';
 import useNear from '../../hooks/useNear';
 import css from './methods.module.css';
@@ -42,12 +42,15 @@ const Tip: React.FC<{ method: string }> = ({ method }) => {
   )
 };
 
-export const Method: React.FC<{ method: string }> = ({ method }) => {
+export const Method: React.FC<{
+  method: string
+  contract?: string
+  isCurrentMethod: boolean
+}> = ({ method, contract, isCurrentMethod }) => {
   const { canCall, wallet } = useNear()
   const user = wallet?.getAccountId() as string
   const [allowed, setAllowed] = useState<boolean>(true)
   const [whyForbidden, setWhyForbidden] = useState<string>()
-  const { contract, method: currentMethod } = useParams<{ contract: string, method: string }>()
 
   useEffect(() => {
     canCall(method, user).then(can => {
@@ -57,7 +60,7 @@ export const Method: React.FC<{ method: string }> = ({ method }) => {
   }, [method, user, canCall])
 
 
-  if (currentMethod === method) {
+  if (isCurrentMethod) {
     return (
       <div>
         {snake(method)}

--- a/src/components/Methods/Methods.tsx
+++ b/src/components/Methods/Methods.tsx
@@ -1,77 +1,20 @@
-import React, { useEffect, useMemo, useState } from "react";
-import toSnake from "to-snake-case";
+import React, { useState } from "react";
 import useNear from '../../hooks/useNear';
 import { Section } from './Section';
-import { Root as Tooltip, Trigger, Content, Arrow } from '@radix-ui/react-tooltip';
-import { Crown } from './Crown'
-import css from './methods.module.css';
-
-type Items = {
-  'Change Methods': (readonly [string, JSX.Element])[]
-  'View Methods': (readonly [string, JSX.Element])[]
-}
 
 export const Methods = () => {
-  const { changeMethods, getDefinition, viewMethods } = useNear()
+  const { changeMethods, viewMethods } = useNear()
 
-  const toItem = useMemo(() => (camel: string) => {
-    const snake = toSnake(camel)
-    const restrictedTo = getDefinition(camel)?.allow
-      ?.map(x => x.replace(/^::/, ''))
-      ?.join(', ')
-
-    const Tip = restrictedTo && (
-      <Tooltip>
-        <Trigger asChild>
-          <span className={css.crown}>
-            <span className="visuallyHidden">Restricted</span>
-            <Crown />
-          </span>
-        </Trigger>
-        <Content className="tooltip">
-          <div className={css.restrictedTo}>
-            <span>Restricted to:</span>
-            <Crown fill="var(--gray-6)" />
-          </div>
-          <div>
-            {restrictedTo}
-          </div>
-          <Arrow />
-        </Content>
-      </Tooltip>
-    )
-
-    return [
-      camel,
-      <>{snake}{Tip}</>
-    ] as const
-  }, [getDefinition])
-
-  const [items, setItems] = useState<Items>({
-    'View Methods': viewMethods.map(toItem),
-    'Change Methods': changeMethods.map(toItem),
-  })
-
-  useEffect(() => {
-    (async () => {
-      setItems({
-        'View Methods': viewMethods.map(toItem),
-        'Change Methods': changeMethods.map(toItem),
-      })
-    })()
-  }, [viewMethods, changeMethods, toItem]);
-
-  if (!items) return null
+  if (!viewMethods && !changeMethods) return null
 
   return (
     <>
-      {Object.entries(items).map(([heading, methods]) => (
-        <Section
-          key={heading}
-          heading={heading}
-          methods={methods}
-        />
-      ))}
+      {viewMethods.length && (
+        <Section heading="View Methods" methods={viewMethods} />
+      )}
+      {changeMethods.length && (
+        <Section heading="Change Methods" methods={changeMethods} />
+      )}
     </>
   )
 }

--- a/src/components/Methods/Methods.tsx
+++ b/src/components/Methods/Methods.tsx
@@ -12,22 +12,13 @@ type Items = {
 }
 
 export const Methods = () => {
-  const {
-    canCall,
-    changeMethods,
-    getDefinition,
-    viewMethods,
-    wallet,
-  } = useNear()
-  const [items, setItems] = useState<Items>()
-  const user = wallet?.getAccountId() as string
+  const { changeMethods, getDefinition, viewMethods } = useNear()
 
-  const toItem = useMemo(() => async (camel: string) => {
+  const toItem = useMemo(() => (camel: string) => {
     const snake = toSnake(camel)
     const restrictedTo = getDefinition(camel)?.allow
       ?.map(x => x.replace(/^::/, ''))
       ?.join(', ')
-    const [allowed, whyForbidden] = await canCall(camel, user)
 
     const Tip = restrictedTo && (
       <Tooltip>
@@ -52,23 +43,20 @@ export const Methods = () => {
 
     return [
       camel,
-      <span
-        className={allowed ? undefined : css.forbidden}
-        title={allowed ? undefined :
-          `Forbidden: ${whyForbidden}`
-        }
-      >
-        {snake}
-        {Tip}
-      </span>
+      <>{snake}{Tip}</>
     ] as const
-  }, [canCall, getDefinition, user])
+  }, [getDefinition])
+
+  const [items, setItems] = useState<Items>({
+    'View Methods': viewMethods.map(toItem),
+    'Change Methods': changeMethods.map(toItem),
+  })
 
   useEffect(() => {
     (async () => {
       setItems({
-        'View Methods': await Promise.all(viewMethods.map(toItem)),
-        'Change Methods': await Promise.all(changeMethods.map(toItem)),
+        'View Methods': viewMethods.map(toItem),
+        'Change Methods': changeMethods.map(toItem),
       })
     })()
   }, [viewMethods, changeMethods, toItem]);

--- a/src/components/Methods/Methods.tsx
+++ b/src/components/Methods/Methods.tsx
@@ -1,18 +1,16 @@
-import React, { useState } from "react";
+import React from "react";
 import useNear from '../../hooks/useNear';
 import { Section } from './Section';
 
 export const Methods = () => {
   const { changeMethods, viewMethods } = useNear()
 
-  if (!viewMethods && !changeMethods) return null
-
   return (
     <>
-      {viewMethods.length && (
+      {viewMethods.length > 0 && (
         <Section heading="View Methods" methods={viewMethods} />
       )}
-      {changeMethods.length && (
+      {changeMethods.length > 0 && (
         <Section heading="Change Methods" methods={changeMethods} />
       )}
     </>

--- a/src/components/Methods/Section.tsx
+++ b/src/components/Methods/Section.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from "react";
-import { useParams, Link } from "react-router-dom";
 import css from './section.module.css';
 import { Root as Collapsible, Trigger, Content } from '@radix-ui/react-collapsible';
+import { Method } from './Method'
 
 export const Section: React.FC<React.PropsWithChildren<{
   heading: string,
   methods: (readonly [string, JSX.Element])[]
 }>> = ({ heading, methods }) => {
   const [open, setOpen] = useState(true)
-  const { contract, method: currentMethod } = useParams<{ contract: string, method: string }>()
 
   if (!methods.length) return null
 
@@ -29,26 +28,9 @@ export const Section: React.FC<React.PropsWithChildren<{
         </Trigger>
       </header>
       <Content className={css.content} forceMount>
-        {methods.map(([method, element]) => {
-          if (currentMethod === method) {
-            return <div key={method}>{element}</div>
-          }
-
-          return (
-            <Link
-              key={method}
-              to={`/${contract}/${method}`}
-              onClick={() => {
-                // clear any params set by NEAR Wallet when navigating to new method
-                window.history.pushState(null, '',
-                  window.location.href.replace(window.location.search, '')
-                )
-              }}
-            >
-              {element}
-            </Link>
-          )
-        })}
+        {methods.map(([method, element]) => (
+          <Method key={method} method={method} element={element} />
+        ))}
       </Content>
     </Collapsible>
   )

--- a/src/components/Methods/Section.tsx
+++ b/src/components/Methods/Section.tsx
@@ -5,7 +5,7 @@ import { Method } from './Method'
 
 export const Section: React.FC<React.PropsWithChildren<{
   heading: string,
-  methods: (readonly [string, JSX.Element])[]
+  methods: string[]
 }>> = ({ heading, methods }) => {
   const [open, setOpen] = useState(true)
 
@@ -28,8 +28,8 @@ export const Section: React.FC<React.PropsWithChildren<{
         </Trigger>
       </header>
       <Content className={css.content} forceMount>
-        {methods.map(([method, element]) => (
-          <Method key={method} method={method} element={element} />
+        {methods.map(method => (
+          <Method key={method} method={method} />
         ))}
       </Content>
     </Collapsible>

--- a/src/components/Methods/Section.tsx
+++ b/src/components/Methods/Section.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from "react";
-import css from './section.module.css';
+import { useParams } from "react-router-dom";
 import { Root as Collapsible, Trigger, Content } from '@radix-ui/react-collapsible';
 import { Method } from './Method'
+import css from './section.module.css';
 
 export const Section: React.FC<React.PropsWithChildren<{
   heading: string,
   methods: string[]
 }>> = ({ heading, methods }) => {
   const [open, setOpen] = useState(true)
+  const { contract, method: currentMethod } = useParams<{ contract: string, method: string }>()
 
-  if (!methods.length) return null
+  if (!contract) return null
 
   return (
     <Collapsible
@@ -28,9 +30,14 @@ export const Section: React.FC<React.PropsWithChildren<{
         </Trigger>
       </header>
       <Content className={css.content} forceMount>
-        {methods.map(method => (
-          <Method key={method} method={method} />
-        ))}
+        {methods.map(method =>
+          <Method
+            key={method}
+            method={method}
+            contract={contract}
+            isCurrentMethod={method === currentMethod}
+          />
+        )}
       </Content>
     </Collapsible>
   )

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -1,3 +1,4 @@
+import equal from 'fast-deep-equal'
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 import {
@@ -61,13 +62,15 @@ export default function useNear(): NearInterface | typeof stub {
       }
 
       const freshSchema = await getSchema(contract)
-      setCache({
-        ...cache,
-        [contract]: {
-          ...init(contract),
-          ...freshSchema,
-        }
-      })
+      if (!equal(freshSchema, schema)) {
+        setCache({
+          ...cache,
+          [contract]: {
+            ...init(contract),
+            ...freshSchema,
+          }
+        })
+      }
     })()
   }, [cache, contract])
 

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -64,7 +64,7 @@ export default function useNear(): NearInterface | typeof stub {
       }
 
       const freshSchema = await getSchema(contract)
-      if (!equal(freshSchema, schema)) {
+      if (!equal(freshSchema.schema, schema?.schema)) {
         setCache({
           ...cache,
           [contract]: {

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -60,11 +60,12 @@ export default function useNear(): NearInterface | typeof stub {
         })
       }
 
+      const freshSchema = await getSchema(contract)
       setCache({
         ...cache,
         [contract]: {
           ...init(contract),
-          ...await getSchema(contract),
+          ...freshSchema,
         }
       })
     })()

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -4,6 +4,7 @@ import {
   ContractInterface,
   init,
   getSchema,
+  getSchemaCached,
   SchemaInterface,
 } from "../near"
 
@@ -25,7 +26,7 @@ const stub = {
   canCall: () => Promise.resolve([true, undefined] as const),
 } as const
 
-type NearInterface = ContractInterface & SchemaInterface
+type NearInterface = ContractInterface & SchemaInterface & { stale?: true }
 
 /**
  * Get `contract` from url params and use it to initialize near connection.
@@ -34,12 +35,31 @@ type NearInterface = ContractInterface & SchemaInterface
  */
 export default function useNear(): NearInterface | typeof stub {
   const { contract } = useParams<{ contract: ContractName }>()
-  const [cache, setCache] = useState<Record<ContractName, NearInterface>>({})
+  const schema = contract && getSchemaCached(contract)
+  const [cache, setCache] = useState<Record<ContractName, NearInterface>>(!schema ? {} : {
+    [contract]: {
+      stale: true,
+      ...init(contract),
+      ...schema,
+    }
+  })
 
   useEffect(() => {
-    if (!contract || cache[contract]) return
+    if (!contract || (cache[contract] && !cache[contract].stale)) return
 
     (async () => {
+      /* First update with schema cached from localStorage while new schema loads from remote endpoint */
+      const schema = getSchemaCached(contract)
+      if (schema) {
+        setCache({
+          ...cache,
+          [contract]: {
+            ...init(contract),
+            ...schema,
+          }
+        })
+      }
+
       setCache({
         ...cache,
         [contract]: {

--- a/src/near/localStorage.ts
+++ b/src/near/localStorage.ts
@@ -1,0 +1,16 @@
+export function get(key: string): any {
+  try {
+    const serializedState = localStorage.getItem(key);
+    if (serializedState === null) {
+      return undefined;
+    }
+    return JSON.parse(serializedState);
+  } catch (err) {
+    return undefined;
+  }
+}
+
+export function set(key: string, state: any): void {
+  const serializedState = JSON.stringify(state);
+  localStorage.setItem(key, serializedState);
+}

--- a/src/near/schema.ts
+++ b/src/near/schema.ts
@@ -157,7 +157,7 @@ export async function getSchema(contract: string): Promise<SchemaInterface> {
   return buildInterface(contract, schema)
 }
 
-const canCallCache: Record<string, Promise<readonly [boolean, string | undefined]>> = {}
+const canCallCache: Record<string, Promise<string | string[]>> = {}
 
 function buildInterface(contract: string, schema: JSONSchema7): SchemaInterface {
   const { near } = init(contract)
@@ -224,44 +224,52 @@ function buildInterface(contract: string, schema: JSONSchema7): SchemaInterface 
     // if no `allows` field, then anyone can call this method; return true
     if (!hasField) return [true, undefined]
 
-    const cacheKey = `canCall:${method}:${account}`
+    const inRestrictedGroup = (await Promise.all(def.allow.map(async accountOrMethod => {
+      // if `allow` value doesn't start with `::`, then it's a literal account name
+      if (accountOrMethod.slice(0, 2) !== '::') {
+        return accountOrMethod === account
+      }
+      // if only has a `::` at beginning, is the name of a method in `contract`
+      if (accountOrMethod.split('::').length === 2) {
+        const [, method] = accountOrMethod.split('::')
+        const accountObj = await near.account(contract);
 
-    canCallCache[cacheKey] = canCallCache[cacheKey] ?? (async () => {
-      const inRestrictedGroup = (await Promise.all(def.allow.map(async accountOrMethod => {
-        // if `allow` value doesn't start with `::`, then it's a literal account name
-        if (accountOrMethod.slice(0, 2) !== '::') {
-          return accountOrMethod === account
-        }
-        // if only has a `::` at beginning, is the name of a method in `contract`
-        if (accountOrMethod.split('::').length === 2) {
-          const [, method] = accountOrMethod.split('::')
-          const accountObj = await near.account(contract);
-          const accounts = Array.from(await accountObj.viewFunction(contract, method))
-          return accounts.includes(account)
-        }
-        const [, contractName, method] = accountOrMethod.split('::')
-        const accountObj = await near.account(contractName);
-        const accounts = Array.from(await accountObj.viewFunction(contract, method))
+        canCallCache[accountOrMethod] = canCallCache[accountOrMethod] ?? (async () => {
+          return accountObj.viewFunction(contract, method)
+        })();
+
+        // TODO check that res is a string or an array of strings
+        const res = await canCallCache[accountOrMethod]
+        const accounts = Array.from(res)
+
         return accounts.includes(account)
-      }))).reduce((acc, inGroup) => acc || inGroup, false)
+      }
+      const [, contractName, method] = accountOrMethod.split('::')
+      const accountObj = await near.account(contractName);
 
-      const restrictedTo = def.allow.map((group, i) => {
-        const suffix = def.allow.length - 1 === i
-          ? ''
-          : def.allow.length - 2 === i
-          ? ' & '
-          : ', '
-        return group.replace(/^::/, '') + suffix
-      }).join('')
+      canCallCache[accountOrMethod] = canCallCache[accountOrMethod] ?? (async () => {
+        return accountObj.viewFunction(contractName, method)
+      })();
 
-      return inRestrictedGroup
-        ? [true, undefined]
-        : [false, `Only callable by ${restrictedTo}`]
-    })()
+      // TODO check that res is a string or an array of strings
+      const res = await canCallCache[accountOrMethod]
+      const accounts = Array.from(res)
 
-    const can = await canCallCache[cacheKey]
+      return accounts.includes(account)
+    }))).reduce((acc, inGroup) => acc || inGroup, false)
 
-    return can
+    const restrictedTo = def.allow.map((group, i) => {
+      const suffix = def.allow.length - 1 === i
+        ? ''
+        : def.allow.length - 2 === i
+        ? ' & '
+        : ', '
+      return group.replace(/^::/, '') + suffix
+    }).join('')
+
+    return inRestrictedGroup
+      ? [true, undefined]
+      : [false, `Only callable by ${restrictedTo}`]
   }
 
   return {

--- a/src/near/schema.ts
+++ b/src/near/schema.ts
@@ -146,8 +146,12 @@ export interface SchemaInterface {
   canCall: (method: string, account: string) => Promise<readonly [boolean, string | undefined]>
 }
 
+const inMemorySchemaCache: Record<string, JSONSchema7 | undefined> = {}
+
 export function getSchemaCached(contract: string): SchemaInterface | undefined {
-  const schema = localStorage.get(contract) as JSONSchema7 | undefined
+  inMemorySchemaCache[contract] = inMemorySchemaCache[contract] ??
+    localStorage.get(contract) as JSONSchema7 | undefined
+  const schema = inMemorySchemaCache[contract]
   if (!schema) return undefined
   return buildInterface(contract, schema)
 }


### PR DESCRIPTION
This uses a couple different strategies to improve performance, especially on initial page load, and especially if you've loaded this contract once before.

The biggest change is that it caches the contract schema in localStorage. It then renders the page from this cache immediately at the next request, while always fetching the latest schema in the background and updating the page if the new one differs.

Read commit messages for more details.