### PR TITLE
fix: style improvements

### DIFF
--- a/src/components/Layout/layout.module.css
+++ b/src/components/Layout/layout.module.css
@@ -17,6 +17,7 @@
   height: 100svh;
   overflow-y: scroll;
   overflow-x: hidden;
+  overscroll-behavior: none;
 }
 
 .topBar {
@@ -46,9 +47,11 @@
 
 .mobileSidebarWrap {
   position: absolute;
+  overflow: hidden;
   width: 90%;
   left: 2.5%;
   z-index: 2;
+  max-height: 50000vh;
 }
 
 @keyframes fadeIn {
@@ -75,16 +78,13 @@
 
 .mobileSidebarWrap[data-state="open"] {
   animation: fadeIn 120ms ease-out forwards;
-  visibility: visible;
 }
 
 .mobileSidebarWrap[data-state="closed"] {
   animation: fadeOut 200ms ease-out forwards;
-  opacity: 0;
-  left: -500vh;
-  visibility: hidden;
+  max-height: 0;
   transition-delay: 200ms;
-  transition-property: visibility left;
+  transition-property: max-height;
   transition-duration: 0ms;
 }
 
@@ -98,12 +98,9 @@
   height: var(--spacing-l);
 }
 
-.menu:after {
-  display: block;
-}
-
-.menu.closed:after {
+.menu .closed:after {
   content: ' ';
+  display: block;
   background: url('./hamburger.svg');
   background-repeat: no-repeat;
   background-size: contain;
@@ -111,8 +108,9 @@
   height: 100%;
 }
 
-.menu.open:after {
+.menu .open:after {
   content: '⨉';
+  display: block;
   font-size: 1.5rem;
   position: relative;
   top: -0.15em;

--- a/src/components/Methods/Method.tsx
+++ b/src/components/Methods/Method.tsx
@@ -74,6 +74,7 @@ export const Method: React.FC<{
 
   return (
     <Link
+      aria-controls="mainContent"
       to={`/${contract}/${method}`}
       onClick={() => {
         // clear any params set by NEAR Wallet when navigating to new method

--- a/src/components/Methods/Section.tsx
+++ b/src/components/Methods/Section.tsx
@@ -18,17 +18,17 @@ export const Section: React.FC<React.PropsWithChildren<{
       open={open}
       className={`${css.section} ${!open && css.closed}`}
     >
-      <header>
+      <label>
         <h3>{heading}</h3>
         <Trigger asChild>
           <button
             className={css.chevron}
             onClick={() => setOpen(!open)}
           >
-            <span className="visuallyHidden">{open ? 'close' : 'open'}</span>
+            <span className="visuallyHidden">{open ? 'Collapse section' : 'Expand section'}</span>
           </button>
         </Trigger>
-      </header>
+      </label>
       <Content className={css.content} forceMount>
         {methods.map(method =>
           <Method

--- a/src/components/Methods/section.module.css
+++ b/src/components/Methods/section.module.css
@@ -1,12 +1,13 @@
-.section header {
+.section label {
   --animationTiming: 150ms;
+  cursor: pointer;
   display: flex;
   justify-content: space-between;
   margin-top: var(--spacing-l);
 }
 
 /* remove top margin on mobile menu */
-.section:first-child header {
+.section:first-child label {
   margin-top: 0;
 }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -403,6 +403,7 @@ fieldset#root > .form-group + .form-group {
 
 .errorHint {
   background: var(--bg-red-gradient);
+  color: var(--white);
   padding: var(--spacing-s);
   border-radius: var(--br-base);
 }


### PR DESCRIPTION
* fix `errorHint` readibility in light mode
* improve a11y; no overflow scroll in firefox

This second item deserves more description! On Firefox, the page scrolled a long way down, past all content. It turns out this was caused by the hidden menu, which should have only been rendered when in mobile (and now is), but was rendered all the time.

Getting this to work properly with a screenreader was harder than expected!  It now works the way I would expect: if the menu is visually hidden, it is hidden from screenreaders as well (the only way to consistently do this was to use `display: none`).

This also fixes some other accessibility (a11y) issues:

* prevent screenreaders from saying "times sign" for the close button
* after navigating to a new method, get it to read the main content (which just changed) right away
* put the sidebar headers into `label` tags, so that clicking anywhere on the heading expands/collapses the section, rather than needing to click precisely on the little chevron icon
* add more context to screenreader-only button text