### PR TITLE
fix: display empty results

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -30,6 +30,7 @@ function hasSuccessValue(obj: {}): obj is { SuccessValue: string } {
 }
 
 function parseResult(result: string): string {
+  if (!result) return result
   return JSON.stringify(
     JSON.parse(Buffer.from(result, 'base64').toString()),
     null,
@@ -45,13 +46,13 @@ const Display: React.FC<React.PropsWithChildren<{
   tx?: string
 }>> = ({ result, error, tx }) => {
   const { config } = useNear()
-  if (!result && !error) return null
+  if (result === undefined && error === undefined) return null
 
   return (
     <>
-      <h1>{result ? "Result" : "Error"}</h1>
-      <pre className={error && css.error}>
-        <code className={css.result}>
+      <h1>{result !== undefined ? "Result" : "Error"}</h1>
+      <pre className={`${error && css.error} ${css.result}`}>
+        <code>
           {result ?? error}
         </code>
       </pre>
@@ -191,7 +192,7 @@ export function Form() {
         const status = res?.status
         if (!status) setResult(undefined)
         else if (isBasic(status)) setResult(status)
-        else if (status.SuccessValue) {
+        else if (status.SuccessValue !== undefined) {
           setResult(parseResult(status.SuccessValue))
         } else if (status.Failure) {
           setResult(`${status.Failure.error_type}: ${status.Failure.error_message}`)

--- a/src/components/Form/form.module.css
+++ b/src/components/Form/form.module.css
@@ -1,5 +1,6 @@
 .result {
   font-size: 1.1em;
+  min-height: var(--spacing-xl);
 }
 
 .error {


### PR DESCRIPTION
if a change method has no return value, still show that, along with link to NEAR Explorer

<img width="519" alt="image" src="https://user-images.githubusercontent.com/221614/172937739-69ac9abd-4740-4d7b-a9f1-7d8c95b6a763.png">
