### PR TITLE
feat: contract-specific authentication

### DIFF
--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,29 +1,42 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
+import { ConnectedWalletAccount } from 'near-api-js'
 import useNear from "../../hooks/useNear"
 import { Dropdown } from ".."
 import { Wallet } from './Wallet'
 import css from './login.module.css'
 
 export function Login() {
-  const { wallet, signIn, signOut } = useNear()
+  const { currentUser, signIn, signOut } = useNear()
+  const [user, setUser] = useState<ConnectedWalletAccount>()
+  const [loaded, setLoaded] = useState(false)
 
-  if (!wallet) return null
+  useEffect(() => {
+    currentUser.then(u => {
+      setUser(u)
+      setLoaded(true)
+    })
+  }, [currentUser])
 
-  const currentUser = wallet.getAccountId()
-
-  const el = currentUser
-    ? <Dropdown
-        trigger={
-          <button title={currentUser}>
-            <Wallet />
-            <span className="ellipsis">
-              {currentUser}
-            </span>
-          </button>
-        }
-        items={[{ children: "Sign Out", onSelect: signOut }]}
-      />
-    : <button onClick={signIn}><Wallet />Sign In</button>;
-
-  return <div className={css.login}>{el}</div>
+  return (
+    <div
+      className={css.login}
+      style={{ visibility: loaded ? undefined : 'hidden' }}
+    >
+      {user ? (
+        <Dropdown
+          trigger={
+            <button title={user.accountId}>
+              <Wallet />
+              <span className="ellipsis">
+                {user.accountId}
+              </span>
+            </button>
+          }
+          items={[{ children: "Sign Out", onSelect: signOut }]}
+        />
+      ) : (
+        <button onClick={signIn}><Wallet />Sign In</button>
+      )}
+    </div>
+  )
 }

--- a/src/components/Methods/Method.tsx
+++ b/src/components/Methods/Method.tsx
@@ -47,18 +47,19 @@ export const Method: React.FC<{
   contract?: string
   isCurrentMethod: boolean
 }> = ({ method, contract, isCurrentMethod }) => {
-  const { canCall, wallet } = useNear()
-  const user = wallet?.getAccountId() as string
+  const { canCall, currentUser } = useNear()
   const [allowed, setAllowed] = useState<boolean>(true)
   const [whyForbidden, setWhyForbidden] = useState<string>()
 
   useEffect(() => {
-    canCall(method, user).then(can => {
-      setAllowed(can[0])
-      setWhyForbidden(can[1] || undefined)
-    })
-  }, [method, user, canCall])
-
+    (async () => {
+      const user = await currentUser
+      canCall(method, user?.accountId).then(can => {
+        setAllowed(can[0])
+        setWhyForbidden(can[1] || undefined)
+      })
+    })()
+  }, [method, currentUser, canCall])
 
   if (isCurrentMethod) {
     return (

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -15,7 +15,7 @@ const stub = {
   contract: undefined,
   config: undefined,
   near: undefined,
-  wallet: undefined,
+  currentUser: Promise.resolve(undefined),
   signIn: () => { },
   signOut: () => { },
   schema: undefined,

--- a/src/near/schema.ts
+++ b/src/near/schema.ts
@@ -143,7 +143,7 @@ export interface SchemaInterface {
    * @param account string Account name that may or may not be allowed to call `method` on `contract`
    * @returns [boolean, string] boolean is true of `account` can call `method` on `contract`, false if not. string contains reason why user is forbidden.
    */
-  canCall: (method: string, account: string) => Promise<readonly [boolean, string | undefined]>
+  canCall: (method: string, account?: string) => Promise<readonly [boolean, string | undefined]>
 }
 
 type InMemoryCachedSchema = SchemaInterface & {
@@ -220,16 +220,16 @@ function buildInterface(contract: string, schema: JSONSchema7): SchemaInterface 
     return def as MethodDefinition
   }
 
-  async function canCall(method: string, account: string): Promise<readonly [false, string]>;
-  async function canCall(method: string, account: string): Promise<readonly [true, undefined]>;
-  async function canCall(method: string, account: string): Promise<readonly [boolean, string | undefined]> {
+  async function canCall(method: string, account?: string): Promise<readonly [false, string]>;
+  async function canCall(method: string, account?: string): Promise<readonly [true, undefined]>;
+  async function canCall(method: string, account?: string): Promise<readonly [boolean, string | undefined]> {
     const def = getDefinition(method)
 
-    if (!def) return [false, `No method "${method}" exists for contract "${contract}"`]
+    if (!def || !def.contractMethod) return [false, `No method "${method}" exists for contract "${contract}"`]
 
+    if (def.contractMethod === 'view') return [true, undefined]
 
-    if (def.contractMethod === 'change' && !account) return [false, 'Must sign in']
-
+    if (!account) return [false, 'Must sign in']
 
     const hasField = hasAllowProperty(def)
 


### PR DESCRIPTION
Rather than returning `wallet` from `near#init`, return `currentUser`.  This needs to make an RPC query to figure out if the key that NAJ stored in localStorage is for the current contract or another, making `currentUser` a promise (the rest of `init` is synchronous, and much of the codebase relies on it staying that way).

I recommend viewing the diff [with indentation changes hidden](https://github.com/raendev/admin/pull/22/files?w=1)