### PR TITLE
build: switch to faster deep equality checker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rjsf/core": "^4.2.0",
         "brotli-dec-wasm": "^1.3.0",
         "buffer": "^6.0.3",
-        "fast-deep-equal": "^3.1.3",
+        "lodash.isequal": "^4.5.0",
         "near-api-js": "github:AhaLabs/near-api-js#develop",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -9356,6 +9356,11 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -21416,6 +21421,11 @@
     },
     "lodash.debounce": {
       "version": "4.0.8"
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.memoize": {
       "version": "4.1.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@rjsf/core": "^4.2.0",
     "brotli-dec-wasm": "^1.3.0",
     "buffer": "^6.0.3",
-    "fast-deep-equal": "^3.1.3",
+    "lodash.isequal": "^4.5.0",
     "near-api-js": "github:AhaLabs/near-api-js#develop",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/hooks/useNear.ts
+++ b/src/hooks/useNear.ts
@@ -1,4 +1,4 @@
-import equal from 'fast-deep-equal'
+import equal from 'lodash.isequal'
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 import {


### PR DESCRIPTION
looks like current versions of [lodash.isequal are faster than fast-deep-equal][1], as noted in #33

  [1]: https://www.measurethat.net/Benchmarks/Show/3940/0/fastdeepequal---lodashisequal#latest_results_block