### PR TITLE
fix: no longer require refresh after sign-in

### DIFF
--- a/src/near/index.ts
+++ b/src/near/index.ts
@@ -84,6 +84,12 @@ export function init(contract: string): ContractInterface {
    * @returns `wallet.account()` if authenticated against given `contract`
    */
   async function getCurrentUser(contract: string): Promise<undefined | naj.ConnectedWalletAccount> {
+    // Use `setTimeout` with no wait time to give the current process time to
+    // finish, and execute the rest of this function at the next tick. This
+    // gives NAJ time to finish setting the new key to localStorage after a
+    // round-trip to NEAR Wallet.
+    await new Promise<void>(res => setTimeout(() => res()))
+
     if (!wallet.getAccountId()) return undefined
 
     const currentUser = wallet.account()


### PR DESCRIPTION
Fixes #37

The actual bug was only triggered when changing from being signed into one contract instead of another. That is:

1. Sign into one contract, it works
2. Visit another contract in the UI, click "Sign In"
3. Afte round-trip to NEAR Wallet, page still says "Sign In" and "Forbidden"
4. Refresh the page, see that you're now logged in correctly

As mentioned in the comment, this was caused by a race condition between NAJ initialization, which checks URL Params set by NEAR Wallet and sets them to localStorage, and the `getCurrentUser` method.

Adding a `setTimeout` with no wait time fixes it.