### PR TITLE
fix: show error-after-success messages

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -30,12 +30,17 @@ function hasSuccessValue(obj: {}): obj is { SuccessValue: string } {
   return 'SuccessValue' in obj
 }
 
+function prettifyJsonString(input: string): string {
+  try {
+    return JSON.stringify(JSON.parse(input), null, 2)
+  } catch {
+    return input
+  }
+}
 function parseResult(result: string): string {
   if (!result) return result
-  return JSON.stringify(
-    JSON.parse(Buffer.from(result, 'base64').toString()),
-    null,
-    2
+  return prettifyJsonString(
+    Buffer.from(result, 'base64').toString()
   )
 }
 
@@ -230,7 +235,7 @@ export function Form() {
     } catch (e: unknown) {
       setError(
         e instanceof Error
-          ? JSON.stringify(e.message, null, 2)
+          ? prettifyJsonString(e.message)
           : JSON.stringify(e)
       )
     } finally {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -188,6 +188,7 @@ export function Form() {
 
   const onSubmit = useMemo(() => async ({ formData }: WrappedFormData) => {
     setLoading(true)
+    setResult(undefined)
     setError(undefined)
     setTx(undefined)
     setLogs(undefined)


### PR DESCRIPTION
If you submit a form successfully and then modify arguments (say, reduce gas below required) and submit again, the error would not be shown. This now shows the error.

Also make the error JSON more readable. It now looks like this:

<img width="577" alt="image" src="https://user-images.githubusercontent.com/221614/178027458-a871e9f8-88b9-4aa9-8391-b8f0f4efa8c3.png">
