### PR TITLE
feat: all strings use textarea

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,13 +1,18 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { JsonRpcProvider, FinalExecutionStatus, FinalExecutionStatusBasic } from 'near-api-js/lib/providers';
-import FormComponent from "@rjsf/core";
+import FormComponent, { WidgetProps } from "@rjsf/core";
+// @ts-expect-error untyped boo!
+import TextareaWidget from "@rjsf/core/lib/components/widgets/TextareaWidget";
 import snake from "to-snake-case";
 import { useParams, useSearchParams } from "react-router-dom"
 import useNear from "../../hooks/useNear"
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 import { WithWBRs } from '..'
-
 import css from "./form.module.css"
+
+const Textarea = (props: WidgetProps) => (
+  <TextareaWidget {...props} options={{rows: 1, ...props.options}} />
+)
 
 type Data = Record<string, any>
 
@@ -289,6 +294,7 @@ export function Form() {
           <FormComponent
             key={method /* re-initialize form when method changes */}
             disabled={!!whyForbidden}
+            widgets={{ TextWidget: Textarea }}
             uiSchema={{
               'ui:submitButtonOptions': {
                 norender: !hasInputs,

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -248,10 +248,15 @@ legend#root_options__title {
 button,
 .button,
 input,
+textarea,
 select {
   border-radius: var(--br-base);
   font: inherit;
   outline: none;
+}
+
+textarea {
+  border-bottom-right-radius: var(--br-small);
 }
 
 button,
@@ -271,6 +276,7 @@ button[type=submit],
 }
 
 input,
+textarea,
 select {
   background-color: transparent;
   border: 2px solid var(--gray-9);
@@ -278,6 +284,7 @@ select {
 }
 
 input,
+textarea,
 select,
 button,
 .button {
@@ -314,6 +321,7 @@ button[disabled],
 }
 
 input:hover:not(:focus),
+textarea:hover:not(:focus),
 select:hover:not(:focus) {
   background: var(--gray-1);
 }
@@ -321,6 +329,9 @@ select:hover:not(:focus) {
 input:hover,
 input:focus,
 input:active,
+textarea:hover,
+textarea:focus,
+textarea:active,
 select:hover,
 select:focus,
 select:active {
@@ -338,11 +349,13 @@ select {
 }
 
 input.error,
+textarea.error,
 select.error {
   border-color: var(--red);
 }
 
-input::selection {
+input::selection,
+textarea::selection {
   background-color: var(--fg);
   color: var(--bg);
 }


### PR DESCRIPTION
- all string inputs use textarea field
- style textarea to mostly look like &lt;input type="string"/&gt;

this allows user to manually resize fields that need longer input, without requiring any extra RAEN Admin-specific comments in the contract code

screenshot:

<img width="307" alt="image" src="https://user-images.githubusercontent.com/221614/182438223-76ba3eaf-fa5f-464d-8eff-f8abf282341d.png">
